### PR TITLE
Add support for pending, undefined it() tests and for data-driving Mocha's before()

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,29 +6,44 @@
 
  module.exports = function(data, fn) {
     var mochaIt = it
-    
+    var mochaBefore = before
+
     data.forEach(function(testData) {
         try {
             it = function(title, f) {
-                
                 for (var key in testData) {
                     title = title.replace('{'+key+'}',testData[key])
                 }
 
-                var testFn = f.length < 2 ? 
+                if (f !== undefined) {
+                    var testFn = f.length < 2 ?
+                        function() {
+                            f(testData)
+                        } :
+                        function(done) {
+                            f(testData,done)
+                        }
+		}
+
+                mochaIt(title, testFn)
+            }
+
+            before = function(f) {
+                var testFn = f.length < 2 ?
                     function() {
                         f(testData)
-                    } : 
+                    } :
                     function(done) {
                         f(testData,done)
                     }
-                    
-                mochaIt(title, testFn)
+
+                mochaBefore(testFn)
             }
 
             fn()
         } finally {
             it = mochaIt
+	    before = mochaBefore
         }
     })
 }


### PR DESCRIPTION
Hi,

I'm using data_driven to test the various responses to a REST API. Since several elements of the HTTP response need to be tested, I thought of using before() to make my HTTP request, and then a series of tests with it() to check various elements of the response.

```
    describe('/my/api/call (GET)', function() {
      data_driven([
        {database: 'empty', expected_response: '0'},
        {database: 'test', expected_response: '106665'}], function() {

        before(function(ctx, done) {
          api_common.prepare_response_object(response_object, ctx.database);
          api_common.make_get_request_and_store_response(databases[ctx.database].url, "/my/api/call", response_object[ctx.database], done);
        });

        it('returns valid JSON for DB {database}', function(ctx) {
          check_proper_json_http_response(response_object[ctx.database].response);
        });

        it('returns HTTP status 200 for DB {database}', function(ctx) {
          response_object[ctx.database].response.status.should.equal(200);
        });

        it('returns {expected_response} as JSON for DB {database}', function(ctx) {
          response_object[ctx.database].response.body.should.equal(parseInt(ctx.expected_response));
        });

        ...

        after(function() {
          api_common.reset_response_object(response_object);
        });
      });
    });
```

The functionality wasn't offered in the current version of the module, therefore I extended index.js to obtain the behavior I needed. I also added support for pending tests through making sure it() would support not having a test function attached to it, like it's the case when using mocha regularly.

This could be useful to the rest of the community, hence this pull request. Note that the modifications done for before() could be applied to after() as well.
