### PR TITLE
Fix a problem with this object passed to each expanded test function

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@
             before = function(f) {
                 var testFn = f.length < 2 ?
                     function() {
-                        f(testData)
+                        f.call(this,testData)
                     } :
                     function(done) {
-                        f(testData,done)
+                        f.call(this,testData,done)
                     }
 
                 mochaBefore(testFn)

--- a/index.js
+++ b/index.js
@@ -18,10 +18,10 @@
                 if (f !== undefined) {
                     var testFn = f.length < 2 ?
                         function() {
-                            f(testData)
+                            f.call(this,testData)
                         } :
                         function(done) {
-                            f(testData,done)
+                            f.call(this,testData,done)
                         }
 		}
 

--- a/test/datadriven.test.js
+++ b/test/datadriven.test.js
@@ -32,7 +32,9 @@ describe('data driven extension', function() {
 				'should not affect tests outside of the dataDriven function',
 				'should run the data driven function with key1',
 				'should allow async data driven testing with key1 value value1',
-				'should allow async data driven testing with key2 value value2'
+				'should allow async data driven testing with key2 value value2',
+				'should pass appropriate this object to sync test function',
+				'should pass appropriate this object to async test function'
 				])
 
 			failed.should.eql([

--- a/test/mocha/tests.js
+++ b/test/mocha/tests.js
@@ -28,12 +28,23 @@ describe('data-driven', function() {
 		})
 
 		dataDriven([{}], function() {
+			before(function(ctx) {
+				this.syncData = sharedData
+			})
+
 			it('should pass appropriate this object to sync test function', function(ctx) {
 				this.sharedData.should.equal(sharedData)
+				this.syncData.should.equal(sharedData)
+			})
+
+			before(function(ctx, done) {
+				this.asyncData = sharedData
+				done()
 			})
 
 			it('should pass appropriate this object to async test function', function(ctx, done) {
 				this.sharedData.should.equal(sharedData)
+				this.asyncData.should.equal(sharedData)
 				done()
 			})
 		})

--- a/test/mocha/tests.js
+++ b/test/mocha/tests.js
@@ -19,4 +19,23 @@ describe('data-driven', function() {
 		it('should allow timeouts for async data driven testing with {key}', function(ctx, done) {			
 		})
 	})
+
+	describe('this object:', function() {
+		var sharedData = 'dummy data'
+
+		beforeEach(function() {
+			this.sharedData = sharedData
+		})
+
+		dataDriven([{}], function() {
+			it('should pass appropriate this object to sync test function', function(ctx) {
+				this.sharedData.should.equal(sharedData)
+			})
+
+			it('should pass appropriate this object to async test function', function(ctx, done) {
+				this.sharedData.should.equal(sharedData)
+				done()
+			})
+		})
+	})
 })


### PR DESCRIPTION
I have noticed that this object in each test function expanded by data-driven module is incorrect.
Due to this, I could not use [mocha-sinon](https://www.npmjs.org/package/mocha-sinon) in data-driven test cases.
So I have added some test cases for reproducing this issue and also fixed it.