### PR TITLE
Allow deep Object lookups for placeholders using dot notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 npm-debug.log
 node_modules
+
+*/.idea

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function(data, fn) {
     var mochaIt = it;
     var mochaBefore = before;
     // Regex used to find tokens, e.g. {foo.bar}, {foo}
-    var re = /{([a-zA-Z\._]+)}/g;
+    var re = /{([0-9a-zA-Z_$\._]+)}/g;
 
     data.forEach(function(testData) {
         try {

--- a/index.js
+++ b/index.js
@@ -4,46 +4,48 @@
  * MIT Licensed
  */
 
- module.exports = function(data, fn) {
-    var mochaIt = it
-    var mochaBefore = before
+module.exports = function(data, fn) {
+    var mochaIt = it;
+    var mochaBefore = before;
 
     data.forEach(function(testData) {
         try {
             it = function(title, f) {
                 for (var key in testData) {
-                    title = title.replace('{'+key+'}',testData[key])
+                    if (testData.hasOwnProperty(key)) {
+                        title = title.replace('{'+key+'}', testData[key]);
+                    }
                 }
 
                 if (f !== undefined) {
                     var testFn = f.length < 2 ?
                         function() {
-                            f.call(this,testData)
+                            f.call(this, testData);
                         } :
                         function(done) {
-                            f.call(this,testData,done)
+                            f.call(this, testData, done);
                         }
-		}
+                }
 
-                mochaIt(title, testFn)
-            }
+                mochaIt(title, testFn);
+            };
 
             before = function(f) {
                 var testFn = f.length < 2 ?
                     function() {
-                        f.call(this,testData)
+                        f.call(this, testData);
                     } :
                     function(done) {
-                        f.call(this,testData,done)
-                    }
+                        f.call(this, testData, done);
+                    };
 
-                mochaBefore(testFn)
-            }
+                mochaBefore(testFn);
+            };
 
-            fn()
+            fn();
         } finally {
-            it = mochaIt
-	    before = mochaBefore
+            it = mochaIt;
+            before = mochaBefore;
         }
     })
-}
+};

--- a/index.js
+++ b/index.js
@@ -4,16 +4,41 @@
  * MIT Licensed
  */
 
+/**
+ * Replaces all tokens in a given test title. This only supports Object lookups using dot notation.
+ *
+ * @param {Array} result Results from the RegExp.prototype.exec invocation
+ * @param {Object} testData The test data set from which we can extract values
+ * @param {String} title The original test title
+ * @return {String} The test title with all tokens replaced with their respective values
+ */
+function replaceTitleTokens(result, testData, title) {
+    var root = testData;
+
+    // Extract the value
+    result[1].split('.').forEach(function (key) {
+        root = root[key];
+    });
+
+    return title.replace(result[0], root);
+}
+
 module.exports = function(data, fn) {
     var mochaIt = it;
     var mochaBefore = before;
+    // Regex used to find tokens, e.g. {foo.bar}, {foo}
+    var re = /{([a-zA-Z\._]+)}/g;
 
     data.forEach(function(testData) {
         try {
             it = function(title, f) {
+                var result;
+
                 for (var key in testData) {
                     if (testData.hasOwnProperty(key)) {
-                        title = title.replace('{'+key+'}', testData[key]);
+                        while (result = re.exec(title)) {
+                            title = replaceTitleTokens(result, testData, title);
+                        }
                     }
                 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-driven",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "data driven testing for mocha",
   "keywords": [
     "mocha",

--- a/test/datadriven.test.js
+++ b/test/datadriven.test.js
@@ -11,42 +11,43 @@ describe('data driven extension', function() {
 	it('should run data driven tests for each data item in the list', function(done) {
 		var mocha = new Mocha
 	  , passed = []
-	  , failed = []
+	  , failed = [];
 
 		function reporter(runner) {
 
 			runner.on('pass', function(test) {
-				passed.push(test.title)
-			})
+				passed.push(test.title);
+			});
 
 			runner.on('fail', function(test) {
-				failed.push(test.title)
-			})
+				failed.push(test.title);
+			});
 		}
 
-		mocha.addFile('test/mocha/tests.js')
-		mocha.reporter(reporter)
-		mocha.timeout(100)
+		mocha.addFile('test/mocha/tests.js');
+		mocha.reporter(reporter);
+		mocha.timeout(100);
 
 		mocha.run(function() {
 			passed.should.eql([
 				'should not affect tests outside of the dataDriven function',
 				'should run the data driven function with key1',
 				'should allow async data driven testing with key1 value value1',
-				'should allow async data driven testing with key2 value value2',
-				'should pass appropriate this object to sync test function',
+                'should allow async data driven testing with key2 value value2',
+                'should handle deep value and deeper value lookups',
+                'should pass appropriate this object to sync test function',
 				'should pass appropriate this object to async test function'
-				])
+				]);
 
 			failed.should.eql([
 				'should allow timeouts for async data driven testing with key1',
   				'should run the data driven function with key2',
   				'should allow timeouts for async data driven testing with key2'
-				])
+				]);
 
-			done()
-		})
-	})
+			done();
+		});
+	});
 
-})
+});
 

--- a/test/datadriven.test.js
+++ b/test/datadriven.test.js
@@ -1,9 +1,10 @@
+'use strict';
 
 /**
  * Module dependencies.
  */
-var Mocha = require('mocha')
-  , should = require('should')
+var Mocha = require('mocha');
+var should = require('should');
 
 describe('data driven extension', function() {
 
@@ -13,12 +14,12 @@ describe('data driven extension', function() {
 	  , failed = []
 
 		function reporter(runner) {
-			
-			runner.on('pass', function(test) {				
+
+			runner.on('pass', function(test) {
 				passed.push(test.title)
 			})
 
-			runner.on('fail', function(test) {				
+			runner.on('fail', function(test) {
 				failed.push(test.title)
 			})
 		}
@@ -26,7 +27,7 @@ describe('data driven extension', function() {
 		mocha.addFile('test/mocha/tests.js')
 		mocha.reporter(reporter)
 		mocha.timeout(100)
-		
+
 		mocha.run(function() {
 			passed.should.eql([
 				'should not affect tests outside of the dataDriven function',

--- a/test/mocha/tests.js
+++ b/test/mocha/tests.js
@@ -1,5 +1,5 @@
-var dataDriven = require('../../')
-  , should = require('should')
+var dataDriven = require('../../');
+var should = require('should');
 
 describe('data-driven', function() {
 	it('should not affect tests outside of the dataDriven function', function() {
@@ -16,37 +16,37 @@ describe('data-driven', function() {
 			done()
 		})
 
-		it('should allow timeouts for async data driven testing with {key}', function(ctx, done) {			
+		it('should allow timeouts for async data driven testing with {key}', function(ctx, done) {
 		})
 	})
 
 	describe('this object:', function() {
-		var sharedData = 'dummy data'
+		var sharedData = 'dummy data';
 
 		beforeEach(function() {
-			this.sharedData = sharedData
+			this.sharedData = sharedData;
 		})
 
 		dataDriven([{}], function() {
 			before(function(ctx) {
-				this.syncData = sharedData
-			})
+				this.syncData = sharedData;
+			});
 
 			it('should pass appropriate this object to sync test function', function(ctx) {
-				this.sharedData.should.equal(sharedData)
-				this.syncData.should.equal(sharedData)
-			})
+				this.sharedData.should.equal(sharedData);
+				this.syncData.should.equal(sharedData);
+			});
 
 			before(function(ctx, done) {
-				this.asyncData = sharedData
-				done()
-			})
+				this.asyncData = sharedData;
+				done();
+			});
 
 			it('should pass appropriate this object to async test function', function(ctx, done) {
-				this.sharedData.should.equal(sharedData)
-				this.asyncData.should.equal(sharedData)
-				done()
-			})
+				this.sharedData.should.equal(sharedData);
+				this.asyncData.should.equal(sharedData);
+				done();
+			});
 		})
 	})
 })

--- a/test/mocha/tests.js
+++ b/test/mocha/tests.js
@@ -2,30 +2,35 @@ var dataDriven = require('../../');
 var should = require('should');
 
 describe('data-driven', function() {
-	it('should not affect tests outside of the dataDriven function', function() {
+    it('should not affect tests outside of the dataDriven function', function() {
 
-	})
+    });
 
-	dataDriven([{key: 'key1',prop: 'value1'},{key: 'key2', prop: 'value2'}], function() {
+	dataDriven([{ key: 'key1', prop: 'value1' }, { key: 'key2', prop: 'value2' }], function() {
 		it('should run the data driven function with {key}', function(ctx) {
 			(ctx.key == 'key1' || ctx.key == 'key2').should.be.true
 			ctx.prop.should.equal('value1') // fail one test
-		})
+		});
 
 		it('should allow async data driven testing with {key} value {prop}', function(ctx, done) {
-			done()
-		})
+			done();
+		});
 
 		it('should allow timeouts for async data driven testing with {key}', function(ctx, done) {
-		})
-	})
+		});
+	});
+
+    dataDriven([{ foo: { bar: 'deep value', oof: { rab: 'deeper value' } }}], function() {
+        it('should handle {foo.bar} and {foo.oof.rab} lookups', function (ctx) {
+        });
+    });
 
 	describe('this object:', function() {
 		var sharedData = 'dummy data';
 
 		beforeEach(function() {
 			this.sharedData = sharedData;
-		})
+		});
 
 		dataDriven([{}], function() {
 			before(function(ctx) {

--- a/test/mocha/tests.js
+++ b/test/mocha/tests.js
@@ -20,8 +20,8 @@ describe('data-driven', function() {
 		});
 	});
 
-    dataDriven([{ foo: { bar: 'deep value', oof: { rab: 'deeper value' } }}], function() {
-        it('should handle {foo.bar} and {foo.oof.rab} lookups', function (ctx) {
+    dataDriven([{ foo: { bar: 'deep value', foo1: { bar1: 'deeper value' } }}], function() {
+        it('should handle {foo.bar} and {foo.foo1.bar1} lookups', function (ctx) {
         });
     });
 


### PR DESCRIPTION
@mjtodd @gcs-github @s-kawaguchi

Firstly, thank you for this handy tool. These changes introduce the possibility for deep Object lookups for placeholders using dot notation.

For example, given the following test data:

`[{ foo: { bar: 'deep value', foo1: { bar1: 'deeper value' } }}]`

And the following test title: `should handle {foo.bar} and {foo.foo1.bar1} lookups`

The resulting test title is: `should handle deep value and deeper value lookups`

Please let me know your thoughts before the documentation is updated, thank you!
