### PR TITLE
make installation instructions a bit simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ describe('some async function', function() {
 
 ## Installation
 
-To start using data-driven, simply add a dependency to ```data-driven``` ```1.2.1``` to your package.json, and run ```npm install```.
+To start using data-driven, simply install it as a dev-dependency (`npm install --save-dev data-driven`).
 
 From the creators of [uncademy.io](http://uncademy.io). Interactive courses for software developers.


### PR DESCRIPTION
I considered the shorthand (`npm i -D data-driven`) but figured it was better to be explicit.

I also removed the explicit version here, so if you make an update you don't have to edit the README again.